### PR TITLE
allow empty artifact list in notifier

### DIFF
--- a/veno-core/src/app.rs
+++ b/veno-core/src/app.rs
@@ -18,9 +18,16 @@ pub struct AppState {
 impl AppState {
     pub fn init(file_path: &str) -> Result<Self> {
         let app_config = AppConfig::load(file_path)?;
-        let app_state = app_config
+        let mut app_state: AppState = app_config
             .try_deserialize()
             .context("Could not deserialize app config")?;
+
+        for notifier in &mut app_state.notifiers {
+            if notifier.artifact_ids.is_empty() {
+                notifier.artifact_ids = app_state.artifacts.iter().map(|x| x.id.clone()).collect();
+            }
+        }
+
         Ok(app_state)
     }
 

--- a/veno-core/src/app.rs
+++ b/veno-core/src/app.rs
@@ -18,15 +18,9 @@ pub struct AppState {
 impl AppState {
     pub fn init(file_path: &str) -> Result<Self> {
         let app_config = AppConfig::load(file_path)?;
-        let mut app_state: AppState = app_config
+        let app_state: AppState = app_config
             .try_deserialize()
             .context("Could not deserialize app config")?;
-
-        for notifier in &mut app_state.notifiers {
-            if notifier.artifact_ids.is_empty() {
-                notifier.artifact_ids = app_state.artifacts.iter().map(|x| x.id.clone()).collect();
-            }
-        }
 
         Ok(app_state)
     }

--- a/veno-core/src/notifier/mod.rs
+++ b/veno-core/src/notifier/mod.rs
@@ -15,6 +15,7 @@ static DEFAULT_MESSAGE_PREFIX: &str = "New version available for";
 pub struct Notifier {
     pub name: String,
     pub sink: Sink,
+    #[serde(default)]
     pub artifact_ids: Vec<String>,
 }
 

--- a/veno-core/src/notifier/mod.rs
+++ b/veno-core/src/notifier/mod.rs
@@ -17,8 +17,29 @@ static DEFAULT_MESSAGE_PREFIX: &str = "New version available for";
 pub struct Notifier {
     pub name: String,
     pub sink: Sink,
-    #[serde(default)]
-    pub artifact_ids: Vec<String>,
+    pub artifact_ids: ArtifactSelection,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum ArtifactSelection {
+    All(AllMarker),
+    Specific(Vec<String>),
+}
+
+impl ArtifactSelection {
+    pub fn contains(&self, other: &str) -> bool {
+        match self {
+            ArtifactSelection::All(_) => true,
+            ArtifactSelection::Specific(ids) => ids.contains(&other.to_string()),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum AllMarker {
+    All,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/veno-web/src/api/notifiers/model.rs
+++ b/veno-web/src/api/notifiers/model.rs
@@ -1,12 +1,12 @@
 use serde::Serialize;
 use utoipa::ToSchema;
-use veno_core::notifier::{Notifier, Sink};
+use veno_core::notifier::{ArtifactSelection, Notifier, Sink};
 
 #[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct NotifierResponse {
     pub name: String,
     pub sink: SinkDto,
-    pub artifact_ids: Vec<String>,
+    pub artifact_ids: ArtifactSelectionDto,
 }
 
 #[derive(Serialize, Debug, Clone, ToSchema)]
@@ -22,6 +22,19 @@ pub enum SinkDto {
     Webhook(WebhookSink),
     #[serde(rename = "console")]
     Console(ConsoleSink),
+}
+
+#[derive(Serialize, Debug, Clone, ToSchema)]
+#[serde(untagged)]
+pub enum ArtifactSelectionDto {
+    All(AllMarker),
+    Specific(Vec<String>),
+}
+
+#[derive(Serialize, Debug, Clone, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum AllMarker {
+    All,
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -56,7 +69,7 @@ impl From<Notifier> for NotifierResponse {
         Self {
             name: value.name,
             sink: value.sink.into(),
-            artifact_ids: value.artifact_ids,
+            artifact_ids: value.artifact_ids.into(),
         }
     }
 }
@@ -81,6 +94,15 @@ impl From<Sink> for SinkDto {
                 webhook: webhook.webhook,
             }),
             Sink::Console(_) => SinkDto::Console(ConsoleSink {}),
+        }
+    }
+}
+
+impl From<ArtifactSelection> for ArtifactSelectionDto {
+    fn from(value: ArtifactSelection) -> Self {
+        match value {
+            ArtifactSelection::All(_) => ArtifactSelectionDto::All(AllMarker::All),
+            ArtifactSelection::Specific(x) => ArtifactSelectionDto::Specific(x),
         }
     }
 }


### PR DESCRIPTION
For a long list of artifacts it can be a pain to track them in the config. This allows you to leave artifact_ids empty, and it will add all tracked artifacts.